### PR TITLE
StoreItem.toPromise()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mobx-fog-of-war ☁️ ⚔️ 🤯
 
-[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.6KB](https://img.shields.io/badge/Size-<1.6KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
+[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.7KB](https://img.shields.io/badge/Size-<1.7KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
 
 ![aoe](https://user-images.githubusercontent.com/345320/91411571-ddf2da80-e88b-11ea-8de7-c0f3462991f4.gif)
 
@@ -17,7 +17,7 @@ If your _server_ is performing data joins (as many graphql APIs tend to do) then
 
 Install with `npm install react mobx mobx-react mobx-fog-of-war`
 
-- Small bundle: `Store` + `asyncRequest` < 1KB gzipped, entire library < 1.6KB gzipped
+- Small bundle: `Store` + `asyncRequest` < 1.1KB gzipped, entire library < 1.7KB gzipped
 - 100% [typescript typed](https://www.typescriptlang.org/)
 - 100% tested with [jest](https://jestjs.io/), [rx marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/internal-marble-tests) and [enzyme](https://github.com/enzymejs/enzyme)
 - Efficient bundling with [rollup](https://rollupjs.org/guide/en/)

--- a/packages/mobx-fog-of-war/.size-limit.js
+++ b/packages/mobx-fog-of-war/.size-limit.js
@@ -2,14 +2,14 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/mobx-fog-of-war.esm.js",
-        limit: "1.6 KB",
+        limit: "1.7 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'argsToKey',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ argsToKey }",
-        limit: "1 KB",
+        limit: "1.1 KB",
         ignore: ['react','mobx']
     },
     {
@@ -23,35 +23,35 @@ module.exports = [
         name: 'provideStores',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ provideStores }",
-        limit: "1.1 KB",
+        limit: "1.2 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'rxBatch',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ rxBatch }",
-        limit: "1.2 KB",
+        limit: "1.3 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'rxRequest',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ rxRequest }",
-        limit: "1.1 KB",
+        limit: "1.2 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'sortByArgsArray',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ sortByArgsArray }",
-        limit: "1 KB",
+        limit: "1.1 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'Store',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ Store }",
-        limit: "1 KB",
+        limit: "1.1 KB",
         ignore: ['react','mobx']
     }
 ];

--- a/packages/mobx-fog-of-war/README.md
+++ b/packages/mobx-fog-of-war/README.md
@@ -1,6 +1,6 @@
 # mobx-fog-of-war ☁️ ⚔️ 🤯
 
-[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.6KB](https://img.shields.io/badge/Size-<1.6KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
+[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.7KB](https://img.shields.io/badge/Size-<1.7KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
 
 ![aoe](https://user-images.githubusercontent.com/345320/91411571-ddf2da80-e88b-11ea-8de7-c0f3462991f4.gif)
 
@@ -17,7 +17,7 @@ If your _server_ is performing data joins (as many graphql APIs tend to do) then
 
 Install with `npm install react mobx mobx-react mobx-fog-of-war`
 
-- Small bundle: `Store` + `asyncRequest` < 1KB gzipped, entire library < 1.6KB gzipped
+- Small bundle: `Store` + `asyncRequest` < 1.1KB gzipped, entire library < 1.7KB gzipped
 - 100% [typescript typed](https://www.typescriptlang.org/)
 - 100% tested with [jest](https://jestjs.io/), [rx marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/internal-marble-tests) and [enzyme](https://github.com/enzymejs/enzyme)
 - Efficient bundling with [rollup](https://rollupjs.org/guide/en/)

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -101,7 +101,7 @@ export class Store<Args,Data,Err> {
     // gets an item, either from cache or by requesting it if required
     // returns the mobx observable for the item
 
-    get = (args: Args, options: GetOptions = {}): StoreItem<Data,Err>|undefined => {
+    get = (args: Args, options: GetOptions = {}): StoreItem<Data,Err> => {
         const key = argsToKey(args);
 
         const item = this.cache.get(key);
@@ -117,10 +117,10 @@ export class Store<Args,Data,Err> {
         };
 
         if(!item || (!item.loading && (!item.hasData || hasItemExpired(item)))) {
-            this.request(args);
+            return this.request(args);
         }
 
-        return this.read(args);
+        return this.read(args) as StoreItem<Data,Err>;
     }
 
     //
@@ -135,7 +135,7 @@ export class Store<Args,Data,Err> {
     // make a request for data
 
     @action
-    request = (args: Args): void => {
+    request = (args: Args): StoreItem<Data,Err> => {
         const key = argsToKey(args);
 
         this.log(`${this.name}: requesting ${key}:`, args);
@@ -149,6 +149,8 @@ export class Store<Args,Data,Err> {
             args,
             requestId: this.requestId
         };
+
+        return this.read(args) as StoreItem<Data,Err>;
     };
 
     // receive() action

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -1,6 +1,7 @@
-import {observable, action} from 'mobx';
+import {observable, action, autorun} from 'mobx';
 import {useEffect} from 'react';
 import {argsToKey} from './argsToKey';
+
 
 export class StoreItem<D,E> {
     @observable loading = false;
@@ -9,6 +10,25 @@ export class StoreItem<D,E> {
     @observable hasError = false;
     @observable error: E|undefined;
     @observable time = new Date(Date.now());
+
+    toPromise = (): Promise<StoreItem<D,E>> => {
+        if(!this.loading) return Promise.resolve(this);
+
+        let resolver: (() => void)|undefined;
+        const promise = new Promise(resolve => {
+            resolver = () => void resolve(this);
+        });
+
+        autorun(reaction => {
+            if(!this.loading) {
+                /* istanbul ignore next */
+                resolver?.();
+                reaction.dispose();
+            }
+        });
+
+        return promise as Promise<StoreItem<D,E>>;
+    };
 }
 
 export interface NextRequest<Args> {

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -420,6 +420,53 @@ describe('Store', () => {
         });
     });
 
+    describe('StoreItem.toPromise()', () => {
+
+        it('should turn the observable item returned from a new request() into a pending promise', async () => {
+            const store = new Store<number,string,string>();
+
+            setTimeout(() => {
+                store.setData(1, 'hello');
+            }, 1000);
+
+            const result = await store.request(1).toPromise();
+
+            expect(result.loading).toBe(false);
+            expect(result.data).toBe('hello');
+        });
+
+        it('should turn the observable item returned from a new request() into a pending promise and resolve on error', async () => {
+            const store = new Store<number,string,string>();
+
+            setTimeout(() => {
+                store.setError(1, 'error');
+            }, 1000);
+
+            const result = await store.request(1).toPromise();
+
+            expect(result.loading).toBe(false);
+            expect(result.error).toBe('error');
+        });
+
+        it('should turn the observable item returned from an existing get() into a resolved promise', async () => {
+            const store = new Store<number,string,string>();
+
+            store.setData(1, 'hello');
+            const item = store.read(1) as StoreItem<string,string>;
+            const result = await item.toPromise();
+            expect(result).toBe(store.read(1));
+        });
+
+        it('should turn the observable item returned from an existing get() into a resolved promise even on error', async () => {
+            const store = new Store<number,string,string>();
+
+            store.setError(1, 'error');
+            const item = store.read(1) as StoreItem<string,string>;
+            const result = await item.toPromise();
+            expect(result).toBe(store.read(1));
+        });
+    });
+
     describe('useGet', () => {
 
         // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -1,6 +1,7 @@
 import {Store, StoreItem, argsToKey} from '../src/index';
 import {mocked} from 'ts-jest/utils';
 import React from 'react';
+import {toJS, autorun} from 'mobx';
 
 const setNow = (ms: number): number => {
     ms = Math.floor(ms);
@@ -275,7 +276,7 @@ describe('Store', () => {
             const store = new Store<number,string,string>();
             store.request = jest.fn(store.request);
 
-            const item = store.get(1) as StoreItem<string,string>;
+            const item = store.get(1);
 
             expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(true);
@@ -399,6 +400,23 @@ describe('Store', () => {
             expect(mocked(store.request)).toHaveBeenCalledTimes(2);
             expect(mocked(store.request).mock.calls[0][0]).toBe(1);
             expect(store.nextRequest && store.nextRequest.requestId).toBe(2);
+        });
+
+        it('request() should always request', () => {
+            const store = new Store<number,string,string>();
+
+            const changes = jest.fn();
+
+            autorun(() => {
+                changes(toJS(store.nextRequest));
+            });
+
+            const item = store.request(1);
+            store.request(1);
+            store.request(1);
+
+            expect(mocked(changes)).toHaveBeenCalledTimes(4); // 3 calls + 1 initial value
+            expect(item.loading).toBe(true);
         });
     });
 


### PR DESCRIPTION
- **BREAKING CHANGE** always return `StoreItem` from `store.get()` and `store.request()`
  - These functions create a `StoreItem` if one doesn't exist so its safe to assert that one will be returned
- Add `StoreItem.toPromise()`
  - Even works if you're using rxjs observables to request the items and they all come back out of order!