### PR TITLE
Feature/no more undefineds

### DIFF
--- a/packages/mobx-fog-of-war/.size-limit.js
+++ b/packages/mobx-fog-of-war/.size-limit.js
@@ -16,7 +16,7 @@ module.exports = [
         name: 'asyncRequest',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ asyncRequest }",
-        limit: "1.1 KB",
+        limit: "1.2 KB",
         ignore: ['react','mobx']
     },
     {
@@ -37,14 +37,14 @@ module.exports = [
         name: 'rxRequest',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ rxRequest }",
-        limit: "1.2 KB",
+        limit: "1.3 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'sortByArgsArray',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ sortByArgsArray }",
-        limit: "1.1 KB",
+        limit: "1.2 KB",
         ignore: ['react','mobx']
     },
     {

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -2,11 +2,10 @@ import {observable, action, autorun} from 'mobx';
 import {useEffect} from 'react';
 import {argsToKey} from './argsToKey';
 
-
 export class StoreItem<D,E> {
     @observable loading = false;
-    @observable hasData = false;
     @observable data: D|undefined;
+    @observable hasData = false;
     @observable hasError = false;
     @observable error: E|undefined;
     @observable time = new Date(Date.now());
@@ -62,7 +61,10 @@ export interface UseGetOptions {
     dependencies?: unknown[];
 }
 
-export class Store<A,D,E> {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NotUndefined = {} | null;
+
+export class Store<A,D extends NotUndefined,E extends NotUndefined> {
 
     name: string;
     staleTime: number;
@@ -206,12 +208,16 @@ export class Store<A,D,E> {
 
     @action
     setData = (args: A, data: D): void => {
+        if(data === undefined) {
+            throw new Error('Data cannot be undefined');
+        }
+
         const key = argsToKey(args);
         this.log(`${this.name}: receiving data for ${key}:`, data);
 
         const item = this._getOrCreate(key);
         item.loading = false;
-        item.hasData = true;
+        item.hasData = data !== undefined;
         item.hasError = false;
         item.error = undefined;
         item.data = data;
@@ -223,12 +229,16 @@ export class Store<A,D,E> {
 
     @action
     setError = (args: A, error: E): void => {
+        if(error === undefined) {
+            throw new Error('Error cannot be undefined');
+        }
+
         const key = argsToKey(args);
         this.log(`${this.name}: receiving error for ${key}:`, error);
 
         const item = this._getOrCreate(key);
         item.loading = false;
-        item.hasError = true;
+        item.hasError = error !== undefined;
         item.error = error;
     };
 

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -97,6 +97,7 @@ export class Store<Args,Data,Err> {
         let item = this.cache.get(key);
         if(!item) {
             item = new StoreItem();
+            item.time = new Date(Date.now());
             this.cache.set(key, item);
         }
         return item;
@@ -111,9 +112,10 @@ export class Store<Args,Data,Err> {
     // so all changes to the item can be observed,
     // or turned into an rxjs observable to be observed that way
 
-    read = (args: Args): StoreItem<Data,Err>|undefined => {
+    @action
+    read = (args: Args): StoreItem<Data,Err> => {
         const key = argsToKey(args);
-        return this.cache.get(key);
+        return this._getOrCreate(key);
     }
 
     // get()
@@ -140,7 +142,7 @@ export class Store<Args,Data,Err> {
             return this.request(args);
         }
 
-        return this.read(args) as StoreItem<Data,Err>;
+        return this.read(args);
     }
 
     //
@@ -170,7 +172,7 @@ export class Store<Args,Data,Err> {
             requestId: this.requestId
         };
 
-        return this.read(args) as StoreItem<Data,Err>;
+        return this.read(args);
     };
 
     // receive() action
@@ -196,7 +198,6 @@ export class Store<Args,Data,Err> {
         const key = argsToKey(args);
         const item = this._getOrCreate(key);
         item.loading = loading;
-        item.time = new Date(Date.now());
     };
 
     // setData() action
@@ -214,7 +215,6 @@ export class Store<Args,Data,Err> {
         item.hasError = false;
         item.error = undefined;
         item.data = data;
-        item.time = new Date(Date.now());
     };
 
     // setData() action
@@ -230,7 +230,6 @@ export class Store<Args,Data,Err> {
         item.loading = false;
         item.hasError = true;
         item.error = error;
-        item.time = new Date(Date.now());
     };
 
     // remove() action

--- a/packages/mobx-fog-of-war/src/asyncRequest.ts
+++ b/packages/mobx-fog-of-war/src/asyncRequest.ts
@@ -1,9 +1,9 @@
 import {autorun, toJS, action} from 'mobx';
 import type {Store} from './Store';
 
-type Requester<Args,Data> = (args: Args) => Promise<Data>;
+type Requester<A,D> = (args: A) => Promise<D>;
 
-export const asyncRequest = <Args,Data,Err>(requester: Requester<Args,Data>) => (store: Store<Args,Data,Err>): void => {
+export const asyncRequest = <A,D,E>(requester: Requester<A,D>) => (store: Store<A,D,E>): void => {
     autorun(() => {
         const nextRequestPlain = toJS(store.nextRequest);
         if(!nextRequestPlain) return;

--- a/packages/mobx-fog-of-war/src/rxRequest.ts
+++ b/packages/mobx-fog-of-war/src/rxRequest.ts
@@ -64,9 +64,9 @@ function toStream<T>(
 // rxRequest
 //
 
-export const rxRequest = <Args,Data,Err>(operator: OperatorFunction<Args, Receive<Args,Data,Err>>) => {
-    return (store: Store<Args,Data,Err>): void => {
-        from(toStream((): NextRequest<Args> => toJS(store.nextRequest) as NextRequest<Args>))
+export const rxRequest = <A,D,E>(operator: OperatorFunction<A, Receive<A,D,E>>) => {
+    return (store: Store<A,D,E>): void => {
+        from(toStream((): NextRequest<A> => toJS(store.nextRequest) as NextRequest<A>))
             .pipe(
                 map(item => item.args),
                 operator

--- a/packages/mobx-fog-of-war/src/sortByArgsArray.ts
+++ b/packages/mobx-fog-of-war/src/sortByArgsArray.ts
@@ -1,23 +1,23 @@
 import {argsToKey} from './argsToKey';
 import type {Receive} from './Store';
 
-export type GetArgs<Args,Data> = (data: Data) => Args;
-export type MissingError<Args,Err> = (args: Args) => Err;
+export type GetArgs<A,D> = (data: D) => A;
+export type MissingError<A,E> = (args: A) => E;
 
-export const sortByArgsArray = <Args,Data,Err>(
-    argsArray: Args[],
-    dataArray: Data[],
-    getArgs: GetArgs<Args,Data>,
-    missingError: MissingError<Args,Err>
-): Receive<Args,Data,Err>[] => {
+export const sortByArgsArray = <A,D,E>(
+    argsArray: A[],
+    dataArray: D[],
+    getArgs: GetArgs<A,D>,
+    missingError: MissingError<A,E>
+): Receive<A,D,E>[] => {
 
-    const dataByKey = new Map<string,Data>();
+    const dataByKey = new Map<string,D>();
 
-    dataArray.forEach((data: Data) => {
+    dataArray.forEach((data: D) => {
         dataByKey.set(argsToKey(getArgs(data)), data);
     });
 
-    return argsArray.map((args: Args): Receive<Args,Data,Err> => {
+    return argsArray.map((args: A): Receive<A,D,E> => {
         const key = argsToKey(args);
         if(dataByKey.has(key)) {
             return {

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -96,6 +96,14 @@ describe('Store', () => {
 
             expect(item.data).toBe('deep');
         });
+
+        it('should not accept undefined', () => {
+            const store = new Store<unknown,string,string>();
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            expect(() => store.setData(1, undefined)).toThrow('Data cannot be undefined');
+        });
     });
 
     describe('setError', () => {
@@ -113,6 +121,14 @@ describe('Store', () => {
             expect(item.hasError).toBe(true);
             expect(item.error).toBe('error');
             expect(item.time.getTime()).toBe(now);
+        });
+
+        it('should not accept undefined', () => {
+            const store = new Store<unknown,string,string>();
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            expect(() => store.setError(1, undefined)).toThrow('Error cannot be undefined');
         });
     });
 

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -1,4 +1,4 @@
-import {Store, StoreItem, argsToKey} from '../src/index';
+import {Store, argsToKey} from '../src/index';
 import {mocked} from 'ts-jest/utils';
 import React from 'react';
 import {toJS, autorun} from 'mobx';
@@ -56,13 +56,12 @@ describe('Store', () => {
 
             const item = store.read(1);
 
-            expect(item).toBe(undefined);
+            expect(item.loading).toBe(false);
 
             store.setLoading(1, true);
 
-            const item2 = store.read(1) as StoreItem<string,string>;
+            const item2 = store.read(1);
 
-            expect(item2 instanceof StoreItem).toBe(true);
             expect(item2.loading).toBe(true);
             expect(item2.hasData).toBe(false); // should not have changed
             expect(item2.data).toBe(undefined); // should not have changed
@@ -79,9 +78,8 @@ describe('Store', () => {
 
             store.setData(1, 'one');
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(true);
             expect(item.data).toBe('one');
@@ -94,9 +92,8 @@ describe('Store', () => {
             const store = new Store<unknown,string,string>();
 
             store.setData({foo:[1,2,3]}, 'deep');
-            const item = store.read({foo:[1,2,3]}) as StoreItem<string,string>;
+            const item = store.read({foo:[1,2,3]});
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.data).toBe('deep');
         });
     });
@@ -108,9 +105,8 @@ describe('Store', () => {
 
             store.setError(1, 'error');
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(false); // should not have changed
             expect(item.data).toBe(undefined); // should not have changed
@@ -128,9 +124,8 @@ describe('Store', () => {
             store.setLoading(1, true);
             store.setData(1, 'one');
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(true);
             expect(item.data).toBe('one');
@@ -146,9 +141,8 @@ describe('Store', () => {
             store.setLoading(1, true);
             store.setError(1, 'error');
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(false); // should not have changed
             expect(item.data).toBe(undefined); // should not have changed
@@ -164,9 +158,8 @@ describe('Store', () => {
             store.setData(1, 'one');
             store.setLoading(1, true);
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(true);
             expect(item.hasData).toBe(true); // should not have changed since setData()
             expect(item.data).toBe('one'); // should not have changed since setData()
@@ -182,9 +175,8 @@ describe('Store', () => {
             store.setError(1, 'error');
             store.setLoading(1, true);
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(true);
             expect(item.hasData).toBe(false); // should not have changed
             expect(item.data).toBe(undefined); // should not have changed
@@ -200,9 +192,8 @@ describe('Store', () => {
             store.setError(1, 'error');
             store.setData(1, 'one');
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(true);
             expect(item.data).toBe('one');
@@ -218,9 +209,8 @@ describe('Store', () => {
             store.setData(1, 'one');
             store.setError(1, 'error');
 
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(true); // should not have changed since setData()
             expect(item.data).toBe('one'); // should not have changed since setData()
@@ -264,10 +254,10 @@ describe('Store', () => {
         it('should remove data from cache', () => {
             const store = new Store<number,string,string>();
 
-            const item = store.read(1);
             store.setData(1, 'one');
             store.remove(1);
-            expect(item).toBe(undefined);
+            const item = store.read(1);
+            expect(item.data).toBe(undefined);
         });
     });
 
@@ -278,7 +268,6 @@ describe('Store', () => {
 
             const item = store.get(1);
 
-            expect(item instanceof StoreItem).toBe(true);
             expect(item.loading).toBe(true);
 
             expect(mocked(store.request)).toHaveBeenCalledTimes(1);
@@ -452,7 +441,7 @@ describe('Store', () => {
             const store = new Store<number,string,string>();
 
             store.setData(1, 'hello');
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
             const result = await item.toPromise();
             expect(result).toBe(store.read(1));
         });
@@ -461,7 +450,7 @@ describe('Store', () => {
             const store = new Store<number,string,string>();
 
             store.setError(1, 'error');
-            const item = store.read(1) as StoreItem<string,string>;
+            const item = store.read(1);
             const result = await item.toPromise();
             expect(result).toBe(store.read(1));
         });

--- a/packages/mobx-fog-of-war/test/asyncRequest.test.ts
+++ b/packages/mobx-fog-of-war/test/asyncRequest.test.ts
@@ -40,7 +40,7 @@ describe('asyncRequest', () => {
         await promise.current;
 
         expect(mocked(changes)).toHaveBeenCalledTimes(3);
-        expect(mocked(changes).mock.calls[0][0]).toBe(undefined);
+        expect(mocked(changes).mock.calls[0][0].loading).toBe(false);
         expect(mocked(changes).mock.calls[1][0].loading).toBe(true);
         expect(mocked(changes).mock.calls[2][0].data).toEqual({
             id: 'a',
@@ -78,7 +78,7 @@ describe('asyncRequest', () => {
         } catch(e) {}
 
         expect(mocked(changes)).toHaveBeenCalledTimes(3);
-        expect(mocked(changes).mock.calls[0][0]).toBe(undefined);
+        expect(mocked(changes).mock.calls[0][0].loading).toBe(false);
         expect(mocked(changes).mock.calls[1][0].loading).toBe(true);
         expect(mocked(changes).mock.calls[2][0].error).toBe('ARGH!');
     });

--- a/packages/mobx-fog-of-war/test/rxRequest.test.ts
+++ b/packages/mobx-fog-of-war/test/rxRequest.test.ts
@@ -26,7 +26,7 @@ describe('rxRequest', () => {
         placeStore.request(1);
 
         expect(mocked(changes)).toHaveBeenCalledTimes(3);
-        expect(mocked(changes).mock.calls[0][0]).toBe(undefined);
+        expect(mocked(changes).mock.calls[0][0].loading).toBe(false);
         expect(mocked(changes).mock.calls[1][0].loading).toBe(true);
         expect(mocked(changes).mock.calls[2][0].data).toBe('data for 1');
 
@@ -59,7 +59,7 @@ describe('rxRequest', () => {
         placeStore.request(1);
 
         expect(mocked(changes)).toHaveBeenCalledTimes(3);
-        expect(mocked(changes).mock.calls[0][0]).toBe(undefined);
+        expect(mocked(changes).mock.calls[0][0].loading).toBe(false);
         expect(mocked(changes).mock.calls[1][0].loading).toBe(true);
         expect(mocked(changes).mock.calls[2][0].error).toBe('ARGH!');
     });


### PR DESCRIPTION
- **BREAKING CHANGE** `undefined` is now prohibited as `data` or as `error` to simplify userland type checking
  - If `data` isn't `undefined`, then it's whatever type generic you told `Store` it should be. Same with `error`.
- **BREAKING CHANGE** make `Store.read()` never return `undefined`. Instead create and return an empty `StoreItem`.
- Refactor typenames to be single letter (apparently this is a common convention as it reduces confusion between "what is a type" and "what is a value", even if the meanings of those types needs some explanation)