### PR TITLE
Feature/aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mobx-fog-of-war ☁️ ⚔️ 🤯
 
-[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.7KB](https://img.shields.io/badge/Size-<1.7KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
+[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.8KB](https://img.shields.io/badge/Size-<1.8KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
 
 ![aoe](https://user-images.githubusercontent.com/345320/91411571-ddf2da80-e88b-11ea-8de7-c0f3462991f4.gif)
 
@@ -17,7 +17,7 @@ If your _server_ is performing data joins (as many graphql APIs tend to do) then
 
 Install with `npm install react mobx mobx-react mobx-fog-of-war`
 
-- Small bundle: `Store` + `asyncRequest` < 1.1KB gzipped, entire library < 1.7KB gzipped
+- Small bundle: `Store` + `asyncRequest` < 1.2KB gzipped, entire library < 1.8KB gzipped
 - 100% [typescript typed](https://www.typescriptlang.org/)
 - 100% tested with [jest](https://jestjs.io/), [rx marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/internal-marble-tests) and [enzyme](https://github.com/enzymejs/enzyme)
 - Efficient bundling with [rollup](https://rollupjs.org/guide/en/)

--- a/packages/mobx-fog-of-war/.size-limit.js
+++ b/packages/mobx-fog-of-war/.size-limit.js
@@ -2,56 +2,56 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/mobx-fog-of-war.esm.js",
-        limit: "1.7 KB",
+        limit: "1.8 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'argsToKey',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ argsToKey }",
-        limit: "1.1 KB",
+        limit: "1.2 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'asyncRequest',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ asyncRequest }",
-        limit: "1.2 KB",
+        limit: "1.3 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'provideStores',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ provideStores }",
-        limit: "1.2 KB",
+        limit: "1.3 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'rxBatch',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ rxBatch }",
-        limit: "1.3 KB",
+        limit: "1.4 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'rxRequest',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ rxRequest }",
-        limit: "1.3 KB",
+        limit: "1.4 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'sortByArgsArray',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ sortByArgsArray }",
-        limit: "1.2 KB",
+        limit: "1.3 KB",
         ignore: ['react','mobx']
     },
     {
         name: 'Store',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ Store }",
-        limit: "1.1 KB",
+        limit: "1.2 KB",
         ignore: ['react','mobx']
     }
 ];

--- a/packages/mobx-fog-of-war/README.md
+++ b/packages/mobx-fog-of-war/README.md
@@ -1,6 +1,6 @@
 # mobx-fog-of-war ☁️ ⚔️ 🤯
 
-[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.7KB](https://img.shields.io/badge/Size-<1.7KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
+[![npm](https://img.shields.io/npm/v/mobx-fog-of-war.svg)](https://www.npmjs.com/package/mobx-fog-of-war) ![Master build](https://github.com/92green/mobx-fog-of-war/workflows/CI/badge.svg?branch=master) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-green) ![Size: <1.8KB](https://img.shields.io/badge/Size-<1.8KB-blue) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Moderate](https://img.shields.io/badge/Coolness-Moderate-blue) 
 
 ![aoe](https://user-images.githubusercontent.com/345320/91411571-ddf2da80-e88b-11ea-8de7-c0f3462991f4.gif)
 
@@ -17,13 +17,15 @@ If your _server_ is performing data joins (as many graphql APIs tend to do) then
 
 Install with `npm install react mobx mobx-react mobx-fog-of-war`
 
-- Small bundle: `Store` + `asyncRequest` < 1.1KB gzipped, entire library < 1.7KB gzipped
+- Small bundle: `Store` + `asyncRequest` < 1.2KB gzipped, entire library < 1.8KB gzipped
 - 100% [typescript typed](https://www.typescriptlang.org/)
 - 100% tested with [jest](https://jestjs.io/), [rx marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/internal-marble-tests) and [enzyme](https://github.com/enzymejs/enzyme)
 - Efficient bundling with [rollup](https://rollupjs.org/guide/en/)
 - Project setup by [tsdx](https://tsdx.io/)
 - Demo site powered by [nextjs](https://nextjs.org/)
 - Monorepo managed with [lerna](https://github.com/lerna/lerna)
+
+## Example Usage
 
 ```js
 import {Store, asyncRequest} from 'mobx-fog-of-war';
@@ -49,7 +51,6 @@ const [StoreProvider, useStore] = provideStores({userStore, petStore});
 
 import React from 'react';
 import {observer} from 'mobx-react';
-import 'mobx-react/batchingForReactDom';
 
 const Main = (props) => {
     return <StoreProvider>
@@ -57,14 +58,14 @@ const Main = (props) => {
     </StoreProvider>;
 };
 
-const Loader = (props) => {
+const Loader = observer(props => {
     let {storeItem, children} = props;
     if(!storeItem) return null;
     if(storeItem.loading) return <div>Loading</div>;
     if(storeItem.hasError) return <div>Error: {storeItem.error.message}</div>;
     if(!storeItem.hasData) return <div>Not found</div>;
     return children();
-};
+});
 
 const UserView = observer(props => {
     const {userStore} = useStore();
@@ -72,7 +73,7 @@ const UserView = observer(props => {
     const user = userFromStore.data;
 
     return <Loader storeItem={userFromStore}>
-        {() => <div>
+        {() => user && <div>
             Name: {user.name}
             Pets: {user.petIds.map(petId => <PetView key={petId} petId={petId} />)}
         </div>}
@@ -81,11 +82,11 @@ const UserView = observer(props => {
 
 const PetView = observer(props => {
     const {petStore} = useStore();
-    const petFromStore = userStore.useGet(props.petId);
+    const petFromStore = petStore.useGet(props.petId);
     const pet = petFromStore.data;
 
     return <Loader storeItem={petFromStore}>
-        {() => <div>
+        {() => pet && <div>
             Pet name: {pet.name}
         </div>}
     </Loader>;

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -157,13 +157,13 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined,AA=string> {
         const item = this.read(args);
 
         const hasItemExpired = (item: StoreItem<D,E>): boolean => {
-            const slateTime: number = typeof options.staleTime === 'number'
+            const staleTime: number = typeof options.staleTime === 'number'
                 ? options.staleTime
                 : this.staleTime;
 
-            if(slateTime === -1) return false;
-            if(slateTime === 0) return true;
-            return new Date(Date.now()) > new Date(item.time.getTime() + slateTime * 1000);
+            if(staleTime === -1) return false;
+            if(staleTime === 0) return true;
+            return new Date(Date.now()) > new Date(item.time.getTime() + staleTime * 1000);
         };
 
         if(!item.loading && (!item.hasData || hasItemExpired(item))) {

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -45,39 +45,46 @@ export type Receive<A,D,E> = {
 
 export type Logger = (...args: unknown[]) => unknown;
 
-export interface StoreOptions<A,D,E> {
+export interface StoreOptions<A,D,E,AA> {
     name?: string;
-    request?: (store: Store<A,D,E>) => void;
+    request?: (store: Store<A,D,E,AA>) => void;
     staleTime?: number;
     log?: Logger;
 }
 
-export interface GetOptions {
+export interface GetOptions<AA> {
     staleTime?: number;
+    alias?: AA;
 }
 
-export interface UseGetOptions {
+export interface RequestOptions<AA> {
+    alias?: AA;
+}
+
+export interface UseGetOptions<AA> {
     staleTime?: number;
     dependencies?: unknown[];
+    alias?: AA;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NotUndefined = {} | null;
 
-export class Store<A,D extends NotUndefined,E extends NotUndefined> {
+export class Store<A,D extends NotUndefined,E extends NotUndefined,AA=string> {
 
     name: string;
     staleTime: number;
     log: Logger;
 
     @observable cache: Map<string, StoreItem<D,E>> = new Map();
+    aliases: Map<string, string> = new Map();
 
     // nextRequest will change each time there is a new request
     // chain off it to go fetch some data
     @observable nextRequest: NextRequest<A>|undefined;
     requestId = 0;
 
-    constructor(options: StoreOptions<A,D,E> = {}) {
+    constructor(options: StoreOptions<A,D,E,AA> = {}) {
         const {
             name = 'unnamed',
             request,
@@ -120,31 +127,50 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined> {
         return this._getOrCreate(key);
     }
 
+    // readAlias()
+    //
+    // reads an item from cache via its alias
+    // aliases are set by get(), request() or useGet()
+    // an alias always refers to a single item in cache at a time
+    // although the item being referred to may change
+
+    @action
+    readAlias = (args: AA): StoreItem<D,E> => {
+        const aliasKey = argsToKey(args);
+        const key = this.aliases.get(aliasKey) || '?';
+        // ^ if alias not found, a '?' empty storeitem item will be created
+        // which will never be updated and is used merely to return from
+        // this and any future calls toreadAlias
+        return this._getOrCreate(key);
+    }
+
     // get()
     //
     // gets an item, either from cache or by requesting it if required
     // returns the mobx observable for the item
 
-    get = (args: A, options: GetOptions = {}): StoreItem<D,E> => {
-        const key = argsToKey(args);
+    get = (args: A, options: GetOptions<AA> = {}): StoreItem<D,E> => {
+        if('alias' in options) {
+            this.setAlias(args, options.alias as AA);
+        }
 
-        const item = this.cache.get(key);
+        const item = this.read(args);
 
         const hasItemExpired = (item: StoreItem<D,E>): boolean => {
-            const staleTime: number = typeof options.staleTime === 'number'
+            const slateTime: number = typeof options.staleTime === 'number'
                 ? options.staleTime
                 : this.staleTime;
 
-            if(staleTime === -1) return false;
-            if(staleTime === 0) return true;
-            return new Date(Date.now()) > new Date(item.time.getTime() + staleTime * 1000);
+            if(slateTime === -1) return false;
+            if(slateTime === 0) return true;
+            return new Date(Date.now()) > new Date(item.time.getTime() + slateTime * 1000);
         };
 
-        if(!item || (!item.loading && (!item.hasData || hasItemExpired(item)))) {
+        if(!item.loading && (!item.hasData || hasItemExpired(item))) {
             return this.request(args);
         }
 
-        return this.read(args);
+        return item;
     }
 
     //
@@ -159,7 +185,11 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined> {
     // make a request for data
 
     @action
-    request = (args: A): StoreItem<D,E> => {
+    request = (args: A, options: RequestOptions<AA> = {}): StoreItem<D,E> => {
+        if('alias' in options) {
+            this.setAlias(args, options.alias as AA);
+        }
+
         const key = argsToKey(args);
 
         this.log(`${this.name}: requesting ${key}:`, args);
@@ -223,7 +253,7 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined> {
         item.data = data;
     };
 
-    // setData() action
+    // setError() action
     //
     // for a given key, set an item's data in cache
 
@@ -242,6 +272,16 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined> {
         item.error = error;
     };
 
+    // setAlias()
+    //
+    // set an alias for a set of args
+
+    setAlias = (args: A, alias: AA): void => {
+        const key = argsToKey(args);
+        const aliasKey = argsToKey(alias);
+        this.aliases.set(aliasKey, key);
+    };
+
     // remove() action
     //
     // for a given key, remove the cached item
@@ -258,9 +298,9 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined> {
     // because React doesn't like side effects during a render
     // call it every render because this'll be deduped upstream anyway
 
-    useGet = (args: A, {staleTime, dependencies = []}: UseGetOptions = {}): StoreItem<D,E>|undefined => {
+    useGet = (args: A, {dependencies = [], ...restOptions}: UseGetOptions<AA> = {}): StoreItem<D,E>|undefined => {
         const key = argsToKey(args);
-        useEffect(() => void this.get(args, {staleTime}), [key, ...dependencies]);
+        useEffect(() => void this.get(args, restOptions), [key, ...dependencies]);
         return this.read(args);
     };
 }

--- a/packages/mobx-fog-of-war/src/argsToKey.ts
+++ b/packages/mobx-fog-of-war/src/argsToKey.ts
@@ -22,5 +22,5 @@ export const argsToKey = (args: unknown): string => {
     }
 
     // stringify result
-    return JSON.stringify(args);
+    return JSON.stringify(args) || '';
 };

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -425,6 +425,55 @@ describe('Store', () => {
         });
     });
 
+    describe('StoreItem aliases', () => {
+        it('should set an alias, and readAlias from that alias', () => {
+            const store = new Store<number,string,string,string>();
+            store.request = jest.fn(store.request);
+
+            store.setData(1, 'hello');
+            store.setData(2, 'hello?');
+            store.setAlias(1, 'foo');
+
+            expect(store.read(1).data).toBe('hello');
+            expect(store.readAlias('foo').data).toBe('hello');
+
+            store.setAlias(2, 'foo');
+            expect(store.readAlias('foo').data).toBe('hello?');
+        });
+
+        it('should get() using an alias, and readAlias from that alias', () => {
+            const store = new Store<number,string,string,string>();
+            store.request = jest.fn(store.request);
+
+            store.get(1, {alias: 'foo'});
+            store.setData(1, 'hello');
+            store.setData(2, 'hello?');
+
+            expect(store.read(1).data).toBe('hello');
+            expect(store.readAlias('foo').data).toBe('hello');
+
+            store.get(2, {alias: 'foo'});
+            expect(store.readAlias('foo').data).toBe('hello?');
+        });
+
+        it('should request() using an alias, and readAlias from that alias', () => {
+            const store = new Store<number,string,string,string>();
+            store.request = jest.fn(store.request);
+
+            expect(store.readAlias('foo').data).toBe(undefined);
+
+            store.request(1, {alias: 'foo'});
+            store.setData(1, 'hello');
+            store.setData(2, 'hello?');
+
+            expect(store.read(1).data).toBe('hello');
+            expect(store.readAlias('foo').data).toBe('hello');
+
+            store.request(2, {alias: 'foo'});
+            expect(store.readAlias('foo').data).toBe('hello?');
+        });
+    });
+
     describe('StoreItem.toPromise()', () => {
 
         it('should turn the observable item returned from a new request() into a pending promise', async () => {

--- a/packages/mobx-fog-of-war/test/argsToKey.test.ts
+++ b/packages/mobx-fog-of-war/test/argsToKey.test.ts
@@ -19,4 +19,8 @@ describe('argsToKey', () => {
         expect(argsToKey({a:null,b:1})).toEqual(argsToKey({b:1}));
         expect(argsToKey({a:undefined,b:1})).toEqual(argsToKey({b:1}));
     });
+
+    it('should produce empty string for undefined', () => {
+        expect(argsToKey(undefined)).toBe('');
+    });
 });


### PR DESCRIPTION
- fix: allow `undefined` to be used as args
- feature: add aliases so requests with different args can share a ref
  - When sending mutations, having a way to key a series of subsequent requests as the same thing without using the payload itself is important