### PR TITLE
Feature/v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ const Loader = observer(props => {
 
 const UserView = observer(props => {
     const {userStore} = useStore();
-    const userFromStore = userStore.useGet(props.userId);
-    const user = userFromStore.data;
+    const [user, userFromStore] = userStore.useGet(props.userId).tuple();
 
     return <Loader storeItem={userFromStore}>
         {() => user && <div>
@@ -82,8 +81,7 @@ const UserView = observer(props => {
 
 const PetView = observer(props => {
     const {petStore} = useStore();
-    const petFromStore = petStore.useGet(props.petId);
-    const pet = petFromStore.data;
+    const [pet, petFromStore] = petStore.useGet(props.petId).tuple();
 
     return <Loader storeItem={petFromStore}>
         {() => pet && <div>

--- a/packages/mobx-fog-of-war-docs/pages/index.tsx
+++ b/packages/mobx-fog-of-war-docs/pages/index.tsx
@@ -189,11 +189,12 @@ const commentFlagStore = new Store<unknown,unknown,string>({
 const placeStore = new Store<PlaceArgs,Place,string>({
     name: 'Place Store!',
     request: rxRequest(
-        rxBatch({
+        rxBatch<PlaceArgs,Place,string,Place>({
             request: argsArray => fakeBatchGetPlace(argsArray),
             bufferTime: 100,
             batch: 10,
             getArgs: item => item.id,
+            getData: item => item,
             requestError: (reason: string) => reason,
             missingError: () => 'not found'
         })

--- a/packages/mobx-fog-of-war/.size-limit.js
+++ b/packages/mobx-fog-of-war/.size-limit.js
@@ -16,7 +16,7 @@ module.exports = [
         name: 'asyncRequest',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ asyncRequest }",
-        limit: "1.3 KB",
+        limit: "1.4 KB",
         ignore: ['react','mobx']
     },
     {
@@ -44,7 +44,7 @@ module.exports = [
         name: 'sortByArgsArray',
         path: "dist/mobx-fog-of-war.esm.js",
         import: "{ sortByArgsArray }",
-        limit: "1.3 KB",
+        limit: "1.4 KB",
         ignore: ['react','mobx']
     },
     {

--- a/packages/mobx-fog-of-war/README.md
+++ b/packages/mobx-fog-of-war/README.md
@@ -69,8 +69,7 @@ const Loader = observer(props => {
 
 const UserView = observer(props => {
     const {userStore} = useStore();
-    const userFromStore = userStore.useGet(props.userId);
-    const user = userFromStore.data;
+    const [user, userFromStore] = userStore.useGet(props.userId).tuple();
 
     return <Loader storeItem={userFromStore}>
         {() => user && <div>
@@ -82,8 +81,7 @@ const UserView = observer(props => {
 
 const PetView = observer(props => {
     const {petStore} = useStore();
-    const petFromStore = petStore.useGet(props.petId);
-    const pet = petFromStore.data;
+    const [pet, petFromStore] = petStore.useGet(props.petId).tuple();
 
     return <Loader storeItem={petFromStore}>
         {() => pet && <div>

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -2,6 +2,11 @@ import {observable, action, autorun} from 'mobx';
 import {useEffect} from 'react';
 import {argsToKey} from './argsToKey';
 
+export type StoreItemTuple<D,E> = [
+    D|undefined,
+    StoreItem<D,E>
+];
+
 export class StoreItem<D,E> {
     @observable loading = false;
     @observable data: D|undefined;
@@ -29,7 +34,7 @@ export class StoreItem<D,E> {
         return promise as Promise<StoreItem<D,E>>;
     };
 
-    tuple = (): [data: D|undefined, storeItem: StoreItem<D,E>] => {
+    tuple = (): StoreItemTuple<D,E> => {
         return [this.data, this];
     };
 }

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -10,7 +10,7 @@ export class StoreItem<D,E> {
     @observable error: E|undefined;
     @observable time = new Date(Date.now());
 
-    toPromise = (): Promise<StoreItem<D,E>> => {
+    promise = (): Promise<StoreItem<D,E>> => {
         if(!this.loading) return Promise.resolve(this);
 
         let resolver: (() => void)|undefined;
@@ -27,6 +27,10 @@ export class StoreItem<D,E> {
         });
 
         return promise as Promise<StoreItem<D,E>>;
+    };
+
+    tuple = (): [data: D|undefined, storeItem: StoreItem<D,E>] => {
+        return [this.data, this];
     };
 }
 

--- a/packages/mobx-fog-of-war/src/sortByArgsArray.ts
+++ b/packages/mobx-fog-of-war/src/sortByArgsArray.ts
@@ -1,20 +1,22 @@
 import {argsToKey} from './argsToKey';
 import type {Receive} from './Store';
 
-export type GetArgs<A,D> = (data: D) => A;
+export type GetArgs<A,R> = (result: R) => A;
+export type GetData<D,R> = (result: R) => D;
 export type MissingError<A,E> = (args: A) => E;
 
-export const sortByArgsArray = <A,D,E>(
+export const sortByArgsArray = <A,D,E,R>(
     argsArray: A[],
-    dataArray: D[],
-    getArgs: GetArgs<A,D>,
+    resultArray: R[],
+    getArgs: GetArgs<A,R>,
+    getData: GetData<D,R>,
     missingError: MissingError<A,E>
 ): Receive<A,D,E>[] => {
 
-    const dataByKey = new Map<string,D>();
+    const dataByKey = new Map<string,R>();
 
-    dataArray.forEach((data: D) => {
-        dataByKey.set(argsToKey(getArgs(data)), data);
+    resultArray.forEach((result: R) => {
+        dataByKey.set(argsToKey(getArgs(result)), result);
     });
 
     return argsArray.map((args: A): Receive<A,D,E> => {
@@ -23,7 +25,7 @@ export const sortByArgsArray = <A,D,E>(
             return {
                 args,
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                data: dataByKey.get(key)!
+                data: getData(dataByKey.get(key)!)
             };
         }
         return {

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -489,7 +489,7 @@ describe('Store', () => {
         });
     });
 
-    describe('StoreItem.toPromise()', () => {
+    describe('StoreItem.promise()', () => {
 
         it('should turn the observable item returned from a new request() into a pending promise', async () => {
             const store = new Store<number,string,string>();
@@ -498,7 +498,7 @@ describe('Store', () => {
                 store.setData(1, 'hello');
             }, 1000);
 
-            const result = await store.request(1).toPromise();
+            const result = await store.request(1).promise();
 
             expect(result.loading).toBe(false);
             expect(result.data).toBe('hello');
@@ -511,7 +511,7 @@ describe('Store', () => {
                 store.setError(1, 'error');
             }, 1000);
 
-            const result = await store.request(1).toPromise();
+            const result = await store.request(1).promise();
 
             expect(result.loading).toBe(false);
             expect(result.error).toBe('error');
@@ -522,7 +522,7 @@ describe('Store', () => {
 
             store.setData(1, 'hello');
             const item = store.read(1);
-            const result = await item.toPromise();
+            const result = await item.promise();
             expect(result).toBe(store.read(1));
         });
 
@@ -531,8 +531,21 @@ describe('Store', () => {
 
             store.setError(1, 'error');
             const item = store.read(1);
-            const result = await item.toPromise();
+            const result = await item.promise();
             expect(result).toBe(store.read(1));
+        });
+    });
+
+    describe('StoreItem.tuple()', () => {
+
+        it('should turn the store item into a duple for easy destructuring', async () => {
+            const store = new Store<number,string,string>();
+            store.setData(1, 'hello');
+            const storeItem = store.read(1);
+            const [data, item] = store.read(1).tuple();
+
+            expect(data).toBe(storeItem.data);
+            expect(item).toBe(storeItem);
         });
     });
 

--- a/packages/mobx-fog-of-war/test/rxBatch.test.ts
+++ b/packages/mobx-fog-of-war/test/rxBatch.test.ts
@@ -83,6 +83,7 @@ describe('rxBatch', () => {
                         bufferTime: 10,
                         batch: 3,
                         getArgs: (item: Data) => item.id,
+                        getData: (item: Data) => item,
                         requestError: e => e,
                         missingError: () => 'missing'
                     })
@@ -134,6 +135,7 @@ describe('rxBatch', () => {
                         bufferTime: 10,
                         batch: 3,
                         getArgs: (item: Data) => item.id,
+                        getData: (item: Data) => item,
                         requestError: e => `error: ${e}`,
                         missingError: () => 'missing'
                     })
@@ -194,6 +196,7 @@ describe('rxBatch', () => {
                         bufferTime: 10,
                         batch: 3,
                         getArgs: (item: Data) => item.id,
+                        getData: (item: Data) => item,
                         requestError: e => e,
                         missingError: () => 'missing'
                     })

--- a/packages/mobx-fog-of-war/test/sortByArgsArray.test.ts
+++ b/packages/mobx-fog-of-war/test/sortByArgsArray.test.ts
@@ -14,17 +14,18 @@ describe('sortbyArgsArray', () => {
             {id: 1, name: 'one'}
         ];
 
-        const result = sortByArgsArray<number,Item,string>(
+        const result = sortByArgsArray<number,string,string,Item>(
             [1,2,3,4],
             items,
-            item => item.id,
+            (item: Item) => item.id,
+            (item: Item) => item.name,
             args => `${args} not found`
         );
 
         expect(result).toEqual([
-            {args: 1, data: {id: 1, name: 'one'}},
-            {args: 2, data: {id: 2, name: 'two'}},
-            {args: 3, data: {id: 3, name: 'three'}},
+            {args: 1, data: 'one'},
+            {args: 2, data: 'two'},
+            {args: 3, data: 'three'},
             {args: 4, error: '4 not found'}
         ]);
 


### PR DESCRIPTION
- **BREAK** `rxBatch` and `sortByArgsArray` now require a `getData` function. Allows for data to be stored that doesn't necessarily have to contain the ids.
- **BREAK** `storeItem.toPromise()` is now `storeItem.promise()`
- Added `storeItem.tuple()` to save one line of code at each usage to get the data off of the store. #8 

```
// both store item and data (e.g. userFromStore and user) are often needed at the same time

// from
const userFromStore = userStore.read(1);
const user = userFromStore.data;

// to
const [user, userFromStore] = userStore.read(1).tuple();
```