### PR TITLE
Disambiguate requesting 0 items and it being successful vs  requesting 0 items and dont request yet

### DIFF
--- a/packages/mobx-fog-of-war-docs/merge.md
+++ b/packages/mobx-fog-of-war-docs/merge.md
@@ -22,7 +22,7 @@ const userAndPetFromStore = mergeStoreItems([userFromStore, petFromStore]);
 ### mergeStoreItems
 
 ```jsx
-mergeStoreItems(storeItems: StoreItem[], priorities = 'e?le:Dl'): StoreItem
+mergeStoreItems(storeItems: StoreItem[]|undefined, priorities = 'e?le:Dl'): StoreItem
 ```
 
 #### storeItems
@@ -50,6 +50,10 @@ For example, `priorities="leD"` tells `mergeStoreItems` to do the following:
 - `"D"` - works like `"d"`, except the test only passes when *all* `storeItems` have data.
 
 If no checks pass, normally no loading statuses are set to `true`. However if `"f"` is added to the end of the priorities string then it will output `.hasData = true`.
+
+If an empty array is passed to `mergeStoreItems`, this is treated as though requests were successful, which by default will return a StoreItem with `.hasData = true`.
+
+If `undefined` is passed to `mergeStoreItems`, this is treated as though a request never took place, which by default will return a StoreItem with `.loading = false`, `.hasError = false` and `.hasData = false`.
 
 Additionally there is the ability to have ternary logic, such as `e?le:Dl`. This example can be understood as *"If there is an error, use `le` as the priorities string. If not, use `Dl` as the priorities string"*.
 

--- a/packages/mobx-fog-of-war-docs/store.md
+++ b/packages/mobx-fog-of-war-docs/store.md
@@ -351,6 +351,7 @@ const MyComponent = (props) => {
 The `useGetMany()` method is a React hook very similar to [useBatchGet()](#storeusebatchget), allowing you to get an arbitrary and variable amount of items, but returning the results in a single merged StoreItem.
 
 - If `undefined` is passed as the first argument, no request will take place.
+- If an empty array is passed as the first argument, no request will take place but the resulting StoreItem will contain `.hasData = true`, as though a request succeeded.
 - The optional `options` object can contain `priorities: string` which are used to determine how loading states are merged; see [mergeStoreItems](Merging StoreItems) for details.
 - The optional `options` object can contain `staleTime: number` to use a different stale time than the Store's default time. For example `{staleTime: 0}` can be used to always force a new request.
 - The optional `options` object can contain `alias: AA`. This creates an alias for the current `args` that can be looked up via [readAlias()](#storereadalias)

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -345,9 +345,7 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined,AA=string> {
     // react hook to get an array of items
     // because React doesn't like side effects during a render
 
-    useBatchGet = (argsArray: A[]|undefined, {dependencies = [], ...restOptions}: UseGetOptions<AA> = {}): StoreItem<D,E>[] => {
-        if(argsArray === undefined) return [];
-
+    useBatchGet = (argsArray: A[]|undefined = [], {dependencies = [], ...restOptions}: UseGetOptions<AA> = {}): StoreItem<D,E>[] => {
         const keys = argsArray.map(args => argsToKey(args));
 
         useEffectVariadic(() => {

--- a/packages/mobx-fog-of-war/src/Store.ts
+++ b/packages/mobx-fog-of-war/src/Store.ts
@@ -364,6 +364,6 @@ export class Store<A,D extends NotUndefined,E extends NotUndefined,AA=string> {
 
     useGetMany = (argsArray: A[]|undefined, {priorities, ...restOptions}: UseGetManyOptions<AA> = {}): StoreItem<D[],E[]> => {
         const storeItems = this.useBatchGet(argsArray, restOptions);
-        return mergeStoreItems(storeItems, priorities);
+        return mergeStoreItems(argsArray ? storeItems : undefined, priorities);
     };
 }

--- a/packages/mobx-fog-of-war/src/mergeStoreItems.ts
+++ b/packages/mobx-fog-of-war/src/mergeStoreItems.ts
@@ -17,9 +17,6 @@ const checkPriority = (storeItems: StoreItem<unknown,unknown>[], type: string): 
     if(type === typeLower) {
         return storeItems.some(dep => dep && dep[prop]);
     }
-    if(storeItems.length === 0) {
-        return false;
-    }
     return storeItems.every(dep => dep && dep[prop]);
 };
 
@@ -40,7 +37,7 @@ export const getPriority = (storeItems: StoreItem<unknown,unknown>[], priorities
     return state.toLowerCase() as Priority;
 };
 
-export function mergeStoreItems<D,E>(storeItems: StoreItem<D,E>[], priorities?: string): StoreItem<D[],E[]>;
+export function mergeStoreItems<D,E>(storeItems?: StoreItem<D,E>[], priorities?: string): StoreItem<D[],E[]>;
 export function mergeStoreItems<D1,E1,D2,E2,D3,E3,D4,E4,D5,E5>(storeItems: [StoreItem<D1,E1>,StoreItem<D2,E2>,StoreItem<D3,E3>,StoreItem<D4,E4>,StoreItem<D5,E5>], priorities?: string): StoreItem<[D1,D2,D3,D4,D5],[E1,E2,E3,E4,E5]>;
 export function mergeStoreItems<D1,E1,D2,E2,D3,E3,D4,E4>(storeItems: [StoreItem<D1,E1>,StoreItem<D2,E2>,StoreItem<D3,E3>,StoreItem<D4,E4>], priorities?: string): StoreItem<[D1,D2,D3,D4],[E1,E2,E3,E4]>;
 export function mergeStoreItems<D1,E1,D2,E2,D3,E3>(storeItems: [StoreItem<D1,E1>,StoreItem<D2,E2>,StoreItem<D3,E3>], priorities?: string): StoreItem<[D1,D2,D3],[E1,E2,E3]>;
@@ -48,6 +45,9 @@ export function mergeStoreItems<D1,E1,D2,E2>(storeItems: [StoreItem<D1,E1>,Store
 export function mergeStoreItems<D1,E1>(storeItems: [StoreItem<D1,E1>], priorities?: string): StoreItem<[D1],[E1]>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function mergeStoreItems(storeItems: any, priorities = 'e?le:Dl'): StoreItem<any,any> {
+    if(storeItems === undefined) {
+        return new StoreItem();
+    }
     const typedStoreItems = storeItems as StoreItem<unknown,unknown>[];
     const priority = getPriority(typedStoreItems, priorities);
     const merged = new StoreItem();

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -695,6 +695,19 @@ describe('Store', () => {
             expect(item instanceof StoreItem).toBe(true);
         });
 
+        it('should accept empty array and return hasData = true', () => {
+            const store = new Store<number,string,string>();
+            store.get = jest.fn();
+
+            const item = store.useGetMany([]);
+            expect(mocked(useEffectVariadic)).toHaveBeenCalledTimes(1);
+
+            expect(item instanceof StoreItem).toBe(true);
+            expect(item.loading).toBe(false);
+            expect(item.hasData).toBe(true);
+            expect(item.hasError).toBe(false);
+        });
+
         it('should not call useEffect() if called with undefined', () => {
             const store = new Store<number,string,string>();
             store.get = jest.fn();
@@ -703,6 +716,17 @@ describe('Store', () => {
             expect(item instanceof StoreItem).toBe(true);
             expect(mocked(useEffectVariadic)).toHaveBeenCalledTimes(0);
             expect(mocked(store.get)).toHaveBeenCalledTimes(0);
+        });
+
+        it('should return blank store item if called with undefined', () => {
+            const store = new Store<number,string,string>();
+            store.get = jest.fn();
+
+            const item = store.useGetMany(undefined);
+            expect(item instanceof StoreItem).toBe(true);
+            expect(item.loading).toBe(false);
+            expect(item.hasData).toBe(false);
+            expect(item.hasError).toBe(false);
         });
 
         it('should call get() with options', () => {

--- a/packages/mobx-fog-of-war/test/Store.test.ts
+++ b/packages/mobx-fog-of-war/test/Store.test.ts
@@ -644,13 +644,13 @@ describe('Store', () => {
             expect(items[2] instanceof StoreItem).toBe(true);
         });
 
-        it('should not call useEffect() if called with undefined', () => {
+        it('should still call useEffect() if called with undefined', () => {
             const store = new Store<number,string,string>();
             store.get = jest.fn();
 
             const items = store.useBatchGet(undefined);
             expect(items).toEqual([]);
-            expect(mocked(useEffectVariadic)).toHaveBeenCalledTimes(0);
+            expect(mocked(useEffectVariadic)).toHaveBeenCalledTimes(1);
             expect(mocked(store.get)).toHaveBeenCalledTimes(0);
         });
 
@@ -706,16 +706,6 @@ describe('Store', () => {
             expect(item.loading).toBe(false);
             expect(item.hasData).toBe(true);
             expect(item.hasError).toBe(false);
-        });
-
-        it('should not call useEffect() if called with undefined', () => {
-            const store = new Store<number,string,string>();
-            store.get = jest.fn();
-
-            const item = store.useGetMany(undefined);
-            expect(item instanceof StoreItem).toBe(true);
-            expect(mocked(useEffectVariadic)).toHaveBeenCalledTimes(0);
-            expect(mocked(store.get)).toHaveBeenCalledTimes(0);
         });
 
         it('should return blank store item if called with undefined', () => {

--- a/packages/mobx-fog-of-war/test/mergeStoreItems.test.tsx
+++ b/packages/mobx-fog-of-war/test/mergeStoreItems.test.tsx
@@ -53,7 +53,7 @@ describe('getPriority', () => {
 
     it('should return priority for empty array', () => {
         expect(getPriority([], 'led')).toBe('n');
-        expect(getPriority([], 'e?le:Dl')).toBe('n');
+        expect(getPriority([], 'e?le:Dl')).toBe('d');
     });
 
 });
@@ -141,10 +141,10 @@ describe('mergeStoreItems', () => {
             expect(merged.hasError).toBe(false);
         });
 
-        it('should preference empty when given no items', () => {
+        it('should preference data when given no items', () => {
             const merged = mergeStoreItems([]);
             expect(merged.loading).toBe(false);
-            expect(merged.hasData).toBe(false);
+            expect(merged.hasData).toBe(true);
             expect(merged.hasError).toBe(false);
         });
 
@@ -196,6 +196,18 @@ describe('mergeStoreItems', () => {
             expect(merged.hasData).toBe(true);
             expect(merged.hasError).toBe(false);
         });
+    });
+
+    describe('undefined items', () => {
+
+        it('should treat undefined storeItems as a non-request', () => {
+            const merged = mergeStoreItems(undefined);
+
+            expect(merged.loading).toBe(false);
+            expect(merged.hasData).toBe(false);
+            expect(merged.hasError).toBe(false);
+        });
+
     });
 
 });


### PR DESCRIPTION
- `mergeStoreItems()` and `store.useGetMany()` treated 0 passed store items as an "empty" operation, but often (but not alwayus) its necessary to merge 0 items or request 0 items and have the result indicate success.
  - pass `undefined` for an empty result, conceptually aligns with other `store` methods
  - pass `[]` for a success result
- `store.useBatchGet()` was not calling `useEffect()` in all cases, so a flick from `undefined` to any array would have thrown a rules-of-hooks error